### PR TITLE
[Refactor] Create Template Cache

### DIFF
--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -1,19 +1,80 @@
 package render
 
 import (
+	"bytes"
 	"fmt"
 	"html/template"
+	"log"
 	"net/http"
+	"path/filepath"
 )
+
+// we will be able to build functions and pass them to the template
+var functions = template.FuncMap{}
 
 // RenderTemplate renders a template with html templates
 func RenderTemplate(w http.ResponseWriter, tmpl string) {
-
-	parsedTemplate, _ := template.ParseFiles("./templates/" + tmpl)
-
-	err := parsedTemplate.Execute(w, nil)
+	tc, err := CreateTemplateCache()
 	if err != nil {
-		fmt.Println("error parsing template:", err)
-		return
+		log.Fatal(err)
 	}
+
+	t, ok := tc[tmpl]
+	if !ok {
+		log.Fatal(err)
+	}
+
+	// holds bytes of templates
+	// It helps to have a buffer so that you can determine where the error occurred more easily
+	buf := new(bytes.Buffer)
+
+	// Takes the template, executes it and store in the buf variable
+	_ = t.Execute(buf, nil)
+	_, err = buf.WriteTo(w)
+
+	if err != nil {
+		fmt.Println("error writing template to browser:", err)
+	}
+}
+
+// CreateTemplateCache creates a map of html templates
+func CreateTemplateCache() (map[string]*template.Template, error) {
+	// Create a new map of templates
+	tmplCache := map[string]*template.Template{}
+
+	// go to the templates directory and get ANYTHING that has page.tmpl
+	pages, err := filepath.Glob("./templates/*.page.tmpl")
+	if err != nil {
+		return tmplCache, err
+	}
+
+	// for each page template...
+	for _, page := range pages {
+		// get the name of the template
+		name := filepath.Base(page)
+
+		// build a new template, pass it our map of custom functions and parse the file
+		ts, err := template.New(name).Funcs(functions).ParseFiles(page)
+		if err != nil {
+			return tmplCache, err
+		}
+
+		// checks in the templates directory for any templates that end in .layout.tmpl
+		matches, err := filepath.Glob("./templates/*.layout.tmpl")
+		if err != nil {
+			return tmplCache, err
+		}
+
+		// if there are any matches, parse the glob
+		if len(matches) > 0 {
+			ts, err = ts.ParseGlob("./templates/*.layout.tmpl")
+			if err != nil {
+				return tmplCache, err
+			}
+		}
+		// let the name of the template map to the value of the new template we created
+		tmplCache[name] = ts
+	}
+
+	return tmplCache, nil
 }

--- a/templates/base.layout.tmpl
+++ b/templates/base.layout.tmpl
@@ -1,0 +1,27 @@
+{{define "base"}} 
+ {{/* everything between these brackets are defined as "base" */}}
+  <!DOCTYPE html>
+  <html lang="en">
+
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  </head>
+   {{block "css" .}}
+
+    {{end}}
+  <body>
+    {{block "content" .}}
+          {{/* Whatever is within this body will change. */}}
+          {{/* It will most likely be data that's passed to the handler to render. */}}
+    {{end}}
+
+    {{block "js" .}}
+
+    {{end}}
+  </body>
+  </html>
+{{end}}

--- a/templates/home.page.tmpl
+++ b/templates/home.page.tmpl
@@ -1,15 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
+{{template "base" .}}
 
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
-</head>
-
-<body>
+{{define "content" }}
   <div class="container">
     <div class="row">
       <div class="col">
@@ -17,6 +8,5 @@
       </div>
     </div>
   </div>  
-</body>
+{{end}}
 
-</html>


### PR DESCRIPTION
This PR refactors templates to use a `base.layout.tmpl` and render relevant html templates using `{{golang directives}}`. 

I learned:
- You have to leave comments on `.tmpl` files inside the `{{double brackets}} as well. There should be no space between the brackets and where the content starts and where it ends. 
- We use a byte buffer in order to determine where bug occurs easier. 